### PR TITLE
Fix building with a non-default library path

### DIFF
--- a/keahook/Makefile
+++ b/keahook/Makefile
@@ -1,7 +1,7 @@
 include ../settings.mk
 
 libkea_python.so: load_unload.cc messages.cc version.cc
-	g++ -std=c++11 -I $(KEA_INC) -I $(PYTHON_INC) -L /usr/local/lib -fpic -shared -o libkea_python.so \
+	g++ -std=c++11 -I $(KEA_INC) -I $(PYTHON_INC) -L $(KEA_LIBS) -fpic -shared -o libkea_python.so \
 		load_unload.cc messages.cc version.cc \
 		-lkea-dhcpsrv -lkea-dhcp++ -lkea-hooks -lkea-log -lkea-util -lkea-exceptions
 


### PR DESCRIPTION
Use `$(KEA_LIBS)` rather than `/usr/local/lib` for the `-L` flag when
building the hook library