### PR TITLE
Remove DHO_URL constant reference

### DIFF
--- a/keamodule/constants.cc
+++ b/keamodule/constants.cc
@@ -125,7 +125,6 @@ static KeaConstant constants[] = {
     constant(DHO_TCODE),
     constant(DHO_NETINFO_ADDR),
     constant(DHO_NETINFO_TAG),
-    constant(DHO_URL),
     constant(DHO_AUTO_CONFIG),
     constant(DHO_NAME_SERVICE_SEARCH),
     constant(DHO_SUBNET_SELECTION),


### PR DESCRIPTION
DHO_URL was removed in Kea 2.1.2 in favour of the renumbered
DHO_V4_CAPTIVE_PORTAL per RFC 8910
